### PR TITLE
openiddict/openiddict-core#682 issue fix on RTM

### DIFF
--- a/Cierge/Cierge.csproj
+++ b/Cierge/Cierge.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="AspNet.Security.OAuth.Validation" Version="2.0.0-*" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.0.0" />
     
-    <PackageReference Include="OpenIddict" Version="2.0.0-rc3-final" />
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="2.0.0-rc3-final" />
-    <PackageReference Include="OpenIddict.Mvc" Version="2.0.0-rc3-final" />
+    <PackageReference Include="OpenIddict" Version="2.0.0" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="OpenIddict.Mvc" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
> In a nutshell, scope permissions were not correctly enforced for public clients using the password flow and custom grant types (confidential clients or clients using the code or client credentials flows were not impacted).