### PR TITLE
Add support for different database providers

### DIFF
--- a/Cierge/Cierge.csproj
+++ b/Cierge/Cierge.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="AspNet.Security.OAuth.Validation" Version="2.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.4" />
-    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.15" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.1.4" />
     
     <PackageReference Include="OpenIddict" Version="2.0.0" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="2.0.0" />

--- a/Cierge/Cierge.csproj
+++ b/Cierge/Cierge.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.6" PrivateAssets="All" />
     <PackageReference Include="AspNet.Security.OAuth.Validation" Version="2.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.4" />
     
     <PackageReference Include="OpenIddict" Version="2.0.0" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="2.0.0" />

--- a/Cierge/Cierge.csproj
+++ b/Cierge/Cierge.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="AspNet.Security.OAuth.Validation" Version="2.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.1.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.4" />
+    <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.15" />
     
     <PackageReference Include="OpenIddict" Version="2.0.0" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="2.0.0" />

--- a/Cierge/Data/DatabaseProvider.cs
+++ b/Cierge/Data/DatabaseProvider.cs
@@ -1,0 +1,7 @@
+enum DatabaseProvider
+{
+    InMemory,
+    MSSQL,
+    PostgreSQL,
+    SQLite
+}

--- a/Cierge/Data/DatabaseProvider.cs
+++ b/Cierge/Data/DatabaseProvider.cs
@@ -1,6 +1,5 @@
 enum DatabaseProvider
 {
-    InMemory,
     MSSQL,
     PostgreSQL,
     SQLite,

--- a/Cierge/Data/DatabaseProvider.cs
+++ b/Cierge/Data/DatabaseProvider.cs
@@ -3,5 +3,6 @@ enum DatabaseProvider
     InMemory,
     MSSQL,
     PostgreSQL,
-    SQLite
+    SQLite,
+    MySQL
 }

--- a/Cierge/Startup.cs
+++ b/Cierge/Startup.cs
@@ -84,6 +84,7 @@ namespace Cierge
                         case DatabaseProvider.MSSQL: options.UseSqlServer(connectionString); break;
                         case DatabaseProvider.PostgreSQL: options.UseNpgsql(connectionString); break;
                         case DatabaseProvider.SQLite: options.UseSqlite(connectionString); break;
+                        case DatabaseProvider.MySQL: options.UseMySQL(connectionString); break;
                         default: throw new ArgumentOutOfRangeException(nameof(provider), provider, $"{provider} is not supported.");
                     }
                 }

--- a/Cierge/Startup.cs
+++ b/Cierge/Startup.cs
@@ -72,8 +72,7 @@ namespace Cierge
 
                 // Cierge:InMemoryDb overrides provider when set to 'true' in the dev environment
                 // InMemory database provider is only supported in the dev environment
-                if (Env.IsDevelopment() && 
-                    ((bool.TryParse(Configuration["Cierge:InMemoryDb"], out var inMemoryDb) && inMemoryDb) || provider == DatabaseProvider.InMemory))
+                if (Env.IsDevelopment() && (bool.TryParse(Configuration["Cierge:InMemoryDb"], out var inMemoryDb) && inMemoryDb))
                 {
                     options.UseInMemoryDatabase("ApplicationDbContext");
                 }

--- a/Cierge/Startup.cs
+++ b/Cierge/Startup.cs
@@ -84,7 +84,7 @@ namespace Cierge
                         case DatabaseProvider.MSSQL: options.UseSqlServer(connectionString); break;
                         case DatabaseProvider.PostgreSQL: options.UseNpgsql(connectionString); break;
                         case DatabaseProvider.SQLite: options.UseSqlite(connectionString); break;
-                        case DatabaseProvider.MySQL: options.UseMySQL(connectionString); break;
+                        case DatabaseProvider.MySQL: options.UseMySql(connectionString); break;
                         default: throw new ArgumentOutOfRangeException(nameof(provider), provider, $"{provider} is not supported.");
                     }
                 }

--- a/Cierge/Startup.cs
+++ b/Cierge/Startup.cs
@@ -57,18 +57,22 @@ namespace Cierge
             services.AddDbContext<ApplicationDbContext>(options =>
             {
                 var dbProviderStr = Configuration["Cierge:DatabaseProvider"];
-                if (!Enum.TryParse(
-                    value: dbProviderStr,
-                    result: out DatabaseProvider provider,
-                    ignoreCase: true))
+                var provider = DatabaseProvider.PostgreSQL;
+                if (!string.IsNullOrWhiteSpace(dbProviderStr) && 
+                    !Enum.TryParse(value: dbProviderStr, result: out provider, ignoreCase: true))
                 {
                     var values = ((DatabaseProvider[])Enum.GetValues(typeof(DatabaseProvider)))
                         .Select(x => x.ToString())
                         .Aggregate((a, b) => $"{a}\n{b}");
-                    throw new ArgumentException("Unable to determine database provider. Use one of:\n{values}");
+                    throw new ArgumentException($"Unable to determine database provider. Use one of:\n{values}");
                 }
 
-                if ((Env.IsDevelopment() && bool.TryParse(Configuration["Cierge:InMemoryDb"], out var inMemoryDb) && inMemoryDb) || provider == DatabaseProvider.InMemory)
+                // default to PostgreSQL provider
+                provider = string.IsNullOrWhiteSpace(dbProviderStr) ? DatabaseProvider.PostgreSQL : provider;
+
+                // Cierge:InMemoryDb overrides provider when set to 'true' in the dev environment
+                if ((Env.IsDevelopment() && bool.TryParse(Configuration["Cierge:InMemoryDb"], out var inMemoryDb) && inMemoryDb) ||
+                     provider == DatabaseProvider.InMemory)
                 {
                     options.UseInMemoryDatabase("ApplicationDbContext");
                 }

--- a/Cierge/Startup.cs
+++ b/Cierge/Startup.cs
@@ -71,8 +71,9 @@ namespace Cierge
                 provider = string.IsNullOrWhiteSpace(dbProviderStr) ? DatabaseProvider.PostgreSQL : provider;
 
                 // Cierge:InMemoryDb overrides provider when set to 'true' in the dev environment
-                if ((Env.IsDevelopment() && bool.TryParse(Configuration["Cierge:InMemoryDb"], out var inMemoryDb) && inMemoryDb) ||
-                     provider == DatabaseProvider.InMemory)
+                // InMemory database provider is only supported in the dev environment
+                if (Env.IsDevelopment() && 
+                    ((bool.TryParse(Configuration["Cierge:InMemoryDb"], out var inMemoryDb) && inMemoryDb) || provider == DatabaseProvider.InMemory))
                 {
                     options.UseInMemoryDatabase("ApplicationDbContext");
                 }

--- a/Cierge/appsettings.json
+++ b/Cierge/appsettings.json
@@ -22,7 +22,7 @@
     "RandomizeFrom": false
   },
   "Cierge": {
-    "DatabaseProvider": "mssql",
+    "DatabaseProvider": "PostgreSQL",
     "RsaSigningKeyJsonPath": "/run/secrets/rsa_signing_key.json",
     "Issuer": "",
     "RequireHttps": "",

--- a/Cierge/appsettings.json
+++ b/Cierge/appsettings.json
@@ -22,6 +22,7 @@
     "RandomizeFrom": false
   },
   "Cierge": {
+    "DatabaseProvider": "mssql",
     "RsaSigningKeyJsonPath": "/run/secrets/rsa_signing_key.json",
     "Issuer": "",
     "RequireHttps": "",

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Here's a walkthrough of the configuration required by Cierge:
     "RandomizeFrom": `boolean: allow addition of random characters before the @ symbol - see issue #18`
   },
   "Cierge": {
-    "DatabaseProvider": `string: Database provider to use. Valid options are InMemory, MSSQL, PostgreSQL, SQLite, and MySQL (case-insensitive).`,
+    "DatabaseProvider": `string: Database provider to use (InMemory, MSSQL, PostgreSQL, SQLite, and MySQL), InMemory supported only in "Development" environment`,
     "RsaSigningKeyJsonPath": `string: OIDC RSA signing json key path (see RsaKeyGenerator), optional, leave empty to generate`,
     "Issuer": `string: OIDC issuer, optional, useful if running behind reverse proxy or using JWTs`,
     "RequireHttps": `boolean: leave off if running behind reverse proxy`,

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Here's a walkthrough of the configuration required by Cierge:
     "RandomizeFrom": `boolean: allow addition of random characters before the @ symbol - see issue #18`
   },
   "Cierge": {
-    "DatabaseProvider": `string: Database provider to use. Valid options are InMemory, MSSQL, PostgreSQL, and SQLite (case-insensitive).`,
+    "DatabaseProvider": `string: Database provider to use. Valid options are InMemory, MSSQL, PostgreSQL, SQLite, and MySQL (case-insensitive).`,
     "RsaSigningKeyJsonPath": `string: OIDC RSA signing json key path (see RsaKeyGenerator), optional, leave empty to generate`,
     "Issuer": `string: OIDC issuer, optional, useful if running behind reverse proxy or using JWTs`,
     "RequireHttps": `boolean: leave off if running behind reverse proxy`,

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Here's a walkthrough of the configuration required by Cierge:
     "RandomizeFrom": `boolean: allow addition of random characters before the @ symbol - see issue #18`
   },
   "Cierge": {
-    "DatabaseProvider": `string: Database provider to use (InMemory, MSSQL, PostgreSQL, SQLite, and MySQL), InMemory supported only in "Development" environment`,
+    "DatabaseProvider": `string: Database provider to use (MSSQL, PostgreSQL, SQLite, and MySQL)`,
     "RsaSigningKeyJsonPath": `string: OIDC RSA signing json key path (see RsaKeyGenerator), optional, leave empty to generate`,
     "Issuer": `string: OIDC issuer, optional, useful if running behind reverse proxy or using JWTs`,
     "RequireHttps": `boolean: leave off if running behind reverse proxy`,
@@ -176,7 +176,7 @@ Here's a walkthrough of the configuration required by Cierge:
     "AppUrl": `string: url of your main website, cosmetic`,
     "Audience": `string: "aud" claim in tokens, required",
     "BeNice": `boolean: display "Powered by Cierge"`,
-    "InMemoryDb": `boolean: overrides DatabaseProvider when set to true in a "Development" (appsettings.Development.json) environment`,
+    "InMemoryDb": `boolean: use in-memory development DB, overrides DatabaseProvider when set to true`,
     "Events": {
       "MaxStored": `number: maximum number of events stored (default 50)`,
       "MaxReturned": `number: maximum number of events displayed per user (default 10)`

--- a/README.md
+++ b/README.md
@@ -146,8 +146,7 @@ Here's a walkthrough of the configuration required by Cierge:
 {
   "ConnectionStrings": {
     "DefaultConnection": `string: a PostgreSQL connection string.
-	                 [Using a different database provider](https://docs.microsoft.com/en-us/ef/core/providers/).
-			 Don't forget to apply database migrations [`dotnet ef database update`](https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/).`
+                          Don't forget to apply database migrations [`dotnet ef database update`](https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/).`
   },
   "Recaptcha": {
     "Secret": `string: reCAPTCHA secret, required`,
@@ -169,6 +168,7 @@ Here's a walkthrough of the configuration required by Cierge:
     "RandomizeFrom": `boolean: allow addition of random characters before the @ symbol - see issue #18`
   },
   "Cierge": {
+    "DatabaseProvider": `string: Database provider to use. Valid options are InMemory, MSSQL, PostgreSQL, and SQLite (case-insensitive).`,
     "RsaSigningKeyJsonPath": `string: OIDC RSA signing json key path (see RsaKeyGenerator), optional, leave empty to generate`,
     "Issuer": `string: OIDC issuer, optional, useful if running behind reverse proxy or using JWTs`,
     "RequireHttps": `boolean: leave off if running behind reverse proxy`,
@@ -176,6 +176,7 @@ Here's a walkthrough of the configuration required by Cierge:
     "AppUrl": `string: url of your main website, cosmetic`,
     "Audience": `string: "aud" claim in tokens, required",
     "BeNice": `boolean: display "Powered by Cierge"`,
+    "InMemoryDb": `boolean: overrides DatabaseProvider when set to true in a "Development" (appsettings.Development.json) environment`,
     "Events": {
       "MaxStored": `number: maximum number of events stored (default 50)`,
       "MaxReturned": `number: maximum number of events displayed per user (default 10)`


### PR DESCRIPTION
Multiple databases other than PostgreSQL are now supported via the configuration option `Cierge:DatabaseProvider`. Supported values are: `MSSQL`, `SQLite`, `PostgreSQL` (default), and `MySQL`.